### PR TITLE
feat: Allow `lazy.nvim` to just handle default config for a plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ When plugins don't conform to the unofficial standard outlined above, then a pla
 
 ```lua
 -- No example configuration was found for this plugin.
---
+-- Using the default configuration for this plugin.
 -- For detailed information on configuring this plugin, please refer to its
 -- official documentation:
 --
@@ -53,7 +53,8 @@ When plugins don't conform to the unofficial standard outlined above, then a pla
 -- the configuration below.
 
 return {
-  -- "cbochs/grapple.nvim"
+  "cbochs/grapple.nvim",
+  opts = {}
 }
 ```
 
@@ -74,5 +75,13 @@ return {
   dependencies = {
     { 'nvim-telescope/telescope.nvim', branch = '0.1.x', dependencies = { 'nvim-lua/plenary.nvim' } }
   }
+}
+```
+
+## Configuration
+
+```lua
+{
+  open_config_after_creation = true
 }
 ```

--- a/README.md
+++ b/README.md
@@ -42,8 +42,7 @@ return {
 When plugins don't conform to the unofficial standard outlined above, then a placeholder config is generated, for example, `$HOME/.config/nvim/lua/plugins/grapple.lua`:
 
 ```lua
--- No example configuration was found for this plugin.
--- Using the default configuration for this plugin.
+-- No example configuration was found for this plugin, a default has been configured.
 -- For detailed information on configuring this plugin, please refer to its
 -- official documentation:
 --

--- a/lua/activate/config.lua
+++ b/lua/activate/config.lua
@@ -1,0 +1,15 @@
+local M = {}
+
+---@class Activate.Config
+M.config = {}
+
+---@class Activate.Config
+local defaults = {
+  open_config_after_creation = true,
+}
+
+M.setup = function(user_config)
+  M.config = vim.tbl_deep_extend("force", defaults, user_config or {})
+end
+
+return M

--- a/lua/activate/init.lua
+++ b/lua/activate/init.lua
@@ -113,6 +113,8 @@ local function create_picker(title, prompt, items, mappings_func)
 	plugin_picker:find()
 end
 
+M.setup = require("activate.config").setup
+
 M.list_plugins = function()
 	local items = utils.get_all_plugins()
 	create_picker(

--- a/lua/activate/types.lua
+++ b/lua/activate/types.lua
@@ -1,0 +1,2 @@
+---@class Activate.Config
+---@field open_config_after_creation boolean Should the newly created configuration open after it is created, default: `true`

--- a/lua/activate/utils.lua
+++ b/lua/activate/utils.lua
@@ -133,7 +133,7 @@ M.create_plugin_file = function(plugin_name, repo, _config, edit)
 			else
 				local disclaimer = [[
         -- No example configuration was found for this plugin.
-        --
+        -- So a default has been configured.
         -- For detailed information on configuring this plugin, please refer to its
         -- official documentation:
         --
@@ -148,7 +148,8 @@ M.create_plugin_file = function(plugin_name, repo, _config, edit)
 				f:write(disclaimer)
 				f:write("\n")
 				f:write("return {\n")
-				f:write(string.format('  -- "%s"\n', repo))
+				f:write(string.format('  "%s",\n', repo))
+				f:write('  opts = {}\n')
 				f:write("}")
 			end
 			f:close()

--- a/lua/activate/utils.lua
+++ b/lua/activate/utils.lua
@@ -1,3 +1,4 @@
+---@module "activate.types"
 local M = {}
 
 local api = vim.api
@@ -327,6 +328,8 @@ local function help()
 end
 
 M.all_plugins_mappings = function(prompt_bufnr, map)
+	---@class Activate.Config
+	local user_conf = require("activate.config").config
 	local action_state = require("telescope.actions.state")
 
 	local function install_and_or_configure_plugin()
@@ -334,7 +337,7 @@ M.all_plugins_mappings = function(prompt_bufnr, map)
 		vim.api.nvim_buf_delete(prompt_bufnr, { force = true })
 		M._install_plugin(entry)
 		local repo_path = entry.url:gsub("https://github.com/", "")
-		local edit = true
+		local edit = user_conf.open_config_after_creation
 		M.create_plugin_file(entry.plugin_name, repo_path, entry.config, edit)
 	end
 

--- a/lua/activate/utils.lua
+++ b/lua/activate/utils.lua
@@ -133,8 +133,7 @@ M.create_plugin_file = function(plugin_name, repo, _config, edit)
 				f:write(config)
 			else
 				local disclaimer = [[
-        -- No example configuration was found for this plugin.
-        -- So a default has been configured.
+        -- No example configuration was found for this plugin, a default has been configured.
         -- For detailed information on configuring this plugin, please refer to its
         -- official documentation:
         --


### PR DESCRIPTION
This PR will default plugins that do not have a `setup.lua.example` to just use `opts = {}` and removes the commented out repo link so the plugin will just work without having to edit the file.

I also added a configuration `open_config_after_creation` which defauts to true; to retain previous behavior or the configuration opening after its installed. It can be set to `false` though to prevent the file from opening.